### PR TITLE
Forgot Family Link

### DIFF
--- a/app/src/components/storefront/StorefrontFamilyRecoveryDialog.tsx
+++ b/app/src/components/storefront/StorefrontFamilyRecoveryDialog.tsx
@@ -1,0 +1,184 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { useForm } from "@tanstack/react-form";
+import { sendFamilyRecoveryLink } from "@/server/functions/family";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { FieldError } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const EMAIL_RE = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+const RECOVERY_CONFIRMATION_MESSAGE =
+  "If an account is associated with that email address, we've sent a family page recovery link. Please check your inbox and spam folder.";
+
+interface StorefrontFamilyRecoveryDialogProps {
+  children: ReactNode;
+}
+
+function getRecoveryErrorMessage(_error: unknown) {
+  return "We couldn't process that request right now. Please try again.";
+}
+
+export function StorefrontFamilyRecoveryDialog({
+  children,
+}: StorefrontFamilyRecoveryDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm({
+    defaultValues: {
+      email: "",
+    },
+    onSubmit: async ({ value }) => {
+      try {
+        setSubmitError(null);
+        setIsSubmitting(true);
+
+        await sendFamilyRecoveryLink({
+          data: { email: value.email.trim().toLowerCase() },
+        });
+
+        setSubmitted(true);
+      } catch (error) {
+        setSubmitError(getRecoveryErrorMessage(error));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+  });
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      form.reset();
+      setSubmitError(null);
+      setSubmitted(false);
+      setIsSubmitting(false);
+    }
+
+    setOpen(nextOpen);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        {!submitted ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Recover family page link</DialogTitle>
+              <DialogDescription>
+                Enter the email address used on your family form and we&apos;ll
+                send the link for your family page if we find a match.
+              </DialogDescription>
+            </DialogHeader>
+
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                form.handleSubmit();
+              }}
+              className="space-y-4"
+            >
+              <form.Field
+                name="email"
+                validators={{
+                  onChange: ({ value }) => {
+                    const normalizedValue = value.trim();
+
+                    if (!normalizedValue) {
+                      return "Email is required";
+                    }
+
+                    if (!EMAIL_RE.test(normalizedValue)) {
+                      return "Enter a valid email address";
+                    }
+
+                    return undefined;
+                  },
+                }}
+              >
+                {(field) => (
+                  <div className="space-y-1.5">
+                    <Label htmlFor={field.name}>Email</Label>
+                    <Input
+                      id={field.name}
+                      type="email"
+                      autoComplete="email"
+                      placeholder="Enter your email"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      aria-invalid={field.state.meta.errors.length > 0}
+                    />
+                    <FieldError
+                      errors={field.state.meta.errors.map((error) => ({
+                        message: String(error),
+                      }))}
+                    />
+                  </div>
+                )}
+              </form.Field>
+
+              {submitError ? (
+                <p className="text-sm text-kfk-red">{submitError}</p>
+              ) : null}
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <form.Subscribe selector={(state) => [state.canSubmit]}>
+                  {([canSubmit]) => (
+                    <Button
+                      type="submit"
+                      disabled={!canSubmit || isSubmitting}
+                      className="bg-kfk-blue hover:bg-kfk-blue/90"
+                    >
+                      {isSubmitting ? "Sending..." : "Send recovery link"}
+                    </Button>
+                  )}
+                </form.Subscribe>
+              </DialogFooter>
+            </form>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Check your email</DialogTitle>
+              <DialogDescription>
+                {RECOVERY_CONFIRMATION_MESSAGE}
+              </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                className="bg-kfk-blue hover:bg-kfk-blue/90"
+                onClick={() => handleOpenChange(false)}
+              >
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/storefront/StorefrontMobileSidebar.tsx
+++ b/app/src/components/storefront/StorefrontMobileSidebar.tsx
@@ -24,6 +24,7 @@ import type { AuthContext } from "@/server/functions/auth";
 import { useLogout } from "@/hooks/mutations/logoutMutation";
 import { Spinner } from "../ui/spinner";
 import { useStorefrontFormLink } from "@/hooks/queries/useStorefrontFormLink";
+import { StorefrontFamilyRecoveryDialog } from "@/components/storefront/StorefrontFamilyRecoveryDialog";
 
 type StorefrontMobileSidebarProps = {
   auth: AuthContext;
@@ -107,15 +108,16 @@ export function StorefrontMobileSidebar({
             </SidebarMenuItem>
 
             <SidebarMenuItem>
-              <SidebarMenuButton asChild size="lg">
-                <Link
-                  to="/"
+              <StorefrontFamilyRecoveryDialog>
+                <SidebarMenuButton
+                  size="lg"
+                  type="button"
                   className="flex items-center gap-3 w-full text-left"
                 >
                   <UsersIcon className="size-6" />
                   <span className="text-base">Family Recovery Link</span>
-                </Link>
-              </SidebarMenuButton>
+                </SidebarMenuButton>
+              </StorefrontFamilyRecoveryDialog>
             </SidebarMenuItem>
 
             <SidebarMenuItem>

--- a/app/src/components/storefront/StorefrontNavbar.tsx
+++ b/app/src/components/storefront/StorefrontNavbar.tsx
@@ -9,6 +9,7 @@ import { UserRole } from "common";
 import type { AuthContext } from "@/server/functions/auth";
 import { useLocalCartData } from "@/hooks/queries/useCartGifts";
 import { useStorefrontFormLink } from "@/hooks/queries/useStorefrontFormLink";
+import { StorefrontFamilyRecoveryDialog } from "@/components/storefront/StorefrontFamilyRecoveryDialog";
 import { Spinner } from "../ui/spinner";
 
 type StorefrontNavbarProps = {
@@ -135,9 +136,14 @@ export function StorefrontNavbar({
       </div>
 
       <div className="max-w-7xl w-full flex flex-col mt-2">
-        <Link className="text-sm underline self-end text-kfk-blue" to="/">
-          Forgot Family Link?
-        </Link>
+        <StorefrontFamilyRecoveryDialog>
+          <button
+            type="button"
+            className="text-sm underline self-end text-kfk-blue cursor-pointer"
+          >
+            Forgot Family Link?
+          </button>
+        </StorefrontFamilyRecoveryDialog>
       </div>
     </div>
   );

--- a/app/src/server/functions/family.ts
+++ b/app/src/server/functions/family.ts
@@ -1,10 +1,16 @@
 import { createServerFn } from "@tanstack/react-start";
+import { Resend } from "resend";
 import z from "zod";
 import type { Child } from "common";
 import { UserRole, FamilySchema, AddressSchema } from "common";
-import { getFamilyLinkById } from "../services/familyLinkService.server";
+import FamilyPortalEmail from "transactional/emails/FamilyPortalEmail";
+import {
+  createFamilyLink,
+  getFamilyLinkById,
+} from "../services/familyLinkService.server";
 import { getServerDB } from "@/lib/firebase.server";
 import { requireRolesMiddleware } from "../middleware/authMiddleware";
+import { appCheckMiddleware } from "../middleware/appCheckMiddleware";
 import type {
   PendingProfileTableRow,
   ApplicationStatus,
@@ -21,6 +27,10 @@ const familyIdInputSchema = z.object({
 
 const driveIdInputSchema = z.object({
   driveId: z.string(),
+});
+
+const familyRecoveryEmailSchema = z.object({
+  email: z.email(),
 });
 
 function getRequiredData<T>(data: T | undefined, errorMessage: string): T {
@@ -69,6 +79,58 @@ export const updateFamilyReviewStatusSchema = z.object({
     privateNotes: z.string().trim().max(2000).optional(),
   }),
 });
+
+function normalizeFamilyEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+function getAppBaseUrl() {
+  const raw = process.env.APP_BASE_URL ?? "https://gifts.kissesforkyle.org";
+  return raw.replace(/\/+$/, "");
+}
+
+function buildFamilyPageUrl(linkId: string) {
+  return `${getAppBaseUrl()}/family/${linkId}/home`;
+}
+
+async function sendRecoveredFamilyLinkEmail({
+  email,
+  contactName,
+  linkId,
+}: {
+  email: string;
+  contactName: string;
+  linkId: string;
+}) {
+  if (!process.env.RESEND_API_KEY) {
+    console.warn("Skipping family recovery email: RESEND_API_KEY is not set");
+    return;
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const familyLink = buildFamilyPageUrl(linkId);
+  const { error } = await resend.emails.send({
+    from: "Kisses for Kyle Gift Registry <noreply@gifts.kissesforkyle.org>",
+    to: email,
+    subject: "Your KFK family page link",
+    react: FamilyPortalEmail({
+      contactName,
+      familyLink,
+      baseUrl: getAppBaseUrl(),
+      previewText: "Your KFK family page link",
+      heading: "Here is your family page link",
+      introText:
+        "We received a request to recover your family page link. Use the link below to return to your family's page.",
+      buttonLabel: "Open Family Page",
+      footerText:
+        "If you did not request this email, you can ignore it. Keep this link somewhere safe so you can come back later.",
+    }),
+  });
+
+  if (error) {
+    throw new Error(`${error.name} - ${error.message}`);
+  }
+}
 
 export const getFamilyByToken = createServerFn({ method: "GET" })
   .inputValidator(tokenInputSchema)

--- a/app/src/server/functions/family.ts
+++ b/app/src/server/functions/family.ts
@@ -132,6 +132,44 @@ async function sendRecoveredFamilyLinkEmail({
   }
 }
 
+export const sendFamilyRecoveryLink = createServerFn({ method: "POST" })
+  .middleware([appCheckMiddleware])
+  .inputValidator(familyRecoveryEmailSchema)
+  .handler(async ({ data }) => {
+    const normalizedEmail = normalizeFamilyEmail(data.email);
+    const db = getServerDB();
+    const familySnapshot = await db.families
+      .where("email", "==", normalizedEmail)
+      .limit(1)
+      .get();
+
+    if (familySnapshot.empty) {
+      return { accepted: true };
+    }
+
+    const familyDoc = familySnapshot.docs[0];
+    const family = getRequiredData(familyDoc.data(), "Family data unavailable");
+    const familyId = family.id || familyDoc.id;
+
+    const activeLinkSnapshot = await db.familyLinks
+      .where("familyId", "==", familyId)
+      .where("active", "==", true)
+      .limit(1)
+      .get();
+
+    const link = activeLinkSnapshot.empty
+      ? await createFamilyLink({ familyId, active: true })
+      : activeLinkSnapshot.docs[0].data();
+
+    await sendRecoveredFamilyLinkEmail({
+      email: normalizedEmail,
+      contactName: family.contactName,
+      linkId: link.id,
+    });
+
+    return { accepted: true };
+  });
+
 export const getFamilyByToken = createServerFn({ method: "GET" })
   .inputValidator(tokenInputSchema)
   .handler(async ({ data }) => {

--- a/transactional/emails/FamilyPortalEmail.tsx
+++ b/transactional/emails/FamilyPortalEmail.tsx
@@ -17,12 +17,22 @@ interface FamilyPortalEmailProps {
   contactName: string;
   familyLink: string;
   baseUrl?: string;
+  previewText?: string;
+  heading?: string;
+  introText?: string;
+  buttonLabel?: string;
+  footerText?: string;
 }
 
 export default function FamilyPortalEmail({
   contactName = "Family",
   familyLink = "https://example.com",
   baseUrl = "http://localhost:5002",
+  previewText = "Your KFK family page is ready",
+  heading = "Your family page is ready",
+  introText = "Thank you for submitting your family's gift drive form. Use the unique link below to view your family page.",
+  buttonLabel = "Open Family Page",
+  footerText = "Please save this email so you can return to your family page later.",
 }: FamilyPortalEmailProps) {
   return (
     <Tailwind
@@ -42,7 +52,7 @@ export default function FamilyPortalEmail({
     >
       <Html lang="en">
         <Head />
-        <Preview>Your KFK family page is ready</Preview>
+        <Preview>{previewText}</Preview>
         <Body className="bg-gray-50 font-sans">
           <Container className="mx-auto max-w-[560px] py-10">
             <Section className="rounded-t-lg bg-gray-200 px-8 py-5 text-center">
@@ -59,12 +69,9 @@ export default function FamilyPortalEmail({
                 Hi {contactName},
               </Text>
               <Heading className="m-0 mb-2 text-2xl font-bold text-gray-900">
-                Your family page is ready
+                {heading}
               </Heading>
-              <Text className="mt-0 text-base text-gray-500">
-                Thank you for submitting your family&apos;s gift drive form. Use
-                the unique link below to view your family page.
-              </Text>
+              <Text className="mt-0 text-base text-gray-500">{introText}</Text>
 
               <Hr className="my-6 border-gray-200" />
 
@@ -72,7 +79,7 @@ export default function FamilyPortalEmail({
                 href={familyLink}
                 className="block rounded-lg bg-kfk-blue px-6 py-3.5 text-center text-sm font-semibold text-white no-underline"
               >
-                Open Family Page
+                {buttonLabel}
               </Button>
 
               <Text className="mb-2 mt-6 text-sm font-semibold uppercase tracking-widest text-gray-400">
@@ -83,8 +90,7 @@ export default function FamilyPortalEmail({
               </Text>
 
               <Text className="mb-0 mt-6 text-sm text-gray-600">
-                Please save this email so you can return to your family page
-                later.
+                {footerText}
               </Text>
             </Section>
 


### PR DESCRIPTION
# Pull Request
When the user clicks on Forgot Family Link, they are greeted with a popup dialog. this will ask for an email associated with family form and if it exists itll email the correct family home page.

By choice we shouldn't present to them if the email doesnt exist in our system. we have a common msg we share after they submit.  `"If an account is associated with that email address, we've sent a family page recovery link. Please check your inbox and spam folder."`
## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues (put task name here from notion)

<!-- Link any related issues here (e.g., Closes #123) -->

## Screenshots (If it is a front end feature screenshot is required)

<!-- If applicable, add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a family link recovery dialog with email entry, loading feedback, and a success state after submission.
  * Added a recovery email flow so users can request a new family page link from the storefront navigation.
* **Bug Fixes**
  * Improved email handling by trimming spaces and normalizing addresses before sending.
  * Reset the recovery dialog cleanly when closed, clearing previous errors and submission state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->