### PR TITLE
111 family form add price

### DIFF
--- a/app/src/components/form/sections/GiftDetails.tsx
+++ b/app/src/components/form/sections/GiftDetails.tsx
@@ -37,6 +37,7 @@ export function GiftDetailsForm({
     giftName?: string;
     giftUrl?: string;
     listedPrice?: string;
+    familyPublicNotes?: string;
   };
   const isGiftRowSelected = (
     giftType: GiftType,
@@ -50,7 +51,40 @@ export function GiftDetailsForm({
     return (
       (overrides?.giftName ?? gift.giftName).trim() !== "" ||
       (overrides?.giftUrl ?? gift.giftUrl).trim() !== "" ||
-      (overrides?.listedPrice ?? gift.listedPrice).trim() !== ""
+      (overrides?.listedPrice ?? gift.listedPrice).trim() !== "" ||
+      (overrides?.familyPublicNotes ?? gift.familyPublicNotes ?? "").trim() !==
+        ""
+    );
+  };
+
+  const validateGiftRowFields = (giftType: GiftType, giftIndex: number) => {
+    if (giftType === "gifts") {
+      void form.validateField(
+        `giftSelections[${childIndex}].gifts[${giftIndex as 0 | 1 | 2}].giftUrl`,
+        "change",
+      );
+      void form.validateField(
+        `giftSelections[${childIndex}].gifts[${giftIndex as 0 | 1 | 2}].giftName`,
+        "change",
+      );
+      void form.validateField(
+        `giftSelections[${childIndex}].gifts[${giftIndex as 0 | 1 | 2}].listedPrice`,
+        "change",
+      );
+      return;
+    }
+
+    void form.validateField(
+      `giftSelections[${childIndex}].backupGifts[${giftIndex as 0 | 1}].giftUrl`,
+      "change",
+    );
+    void form.validateField(
+      `giftSelections[${childIndex}].backupGifts[${giftIndex as 0 | 1}].giftName`,
+      "change",
+    );
+    void form.validateField(
+      `giftSelections[${childIndex}].backupGifts[${giftIndex as 0 | 1}].listedPrice`,
+      "change",
     );
   };
 
@@ -285,6 +319,7 @@ export function GiftDetailsForm({
               name={`giftSelections[${childIndex}].gifts[${i}].familyPublicNotes`}
               validators={{
                 onChange: ({ value }) => {
+                  validateGiftRowFields("gifts", i);
                   if (!value) return undefined;
                   if (value.length > MAX_GIFT_FAMILY_PUBLIC_NOTES_LENGTH) {
                     return GIFT_FAMILY_PUBLIC_NOTES_TOO_LONG_MESSAGE;
@@ -445,6 +480,7 @@ export function GiftDetailsForm({
               name={`giftSelections[${childIndex}].backupGifts[${i}].familyPublicNotes`}
               validators={{
                 onChange: ({ value }) => {
+                  validateGiftRowFields("backupGifts", i);
                   if (!value) return undefined;
                   if (value.length > MAX_GIFT_FAMILY_PUBLIC_NOTES_LENGTH) {
                     return GIFT_FAMILY_PUBLIC_NOTES_TOO_LONG_MESSAGE;

--- a/app/src/components/form/sections/GiftDetails.tsx
+++ b/app/src/components/form/sections/GiftDetails.tsx
@@ -33,19 +33,24 @@ export function GiftDetailsForm({
   const lastFetchedUrlRef = useRef<Record<string, string>>({});
 
   type GiftType = "gifts" | "backupGifts";
+  type GiftFieldOverrides = {
+    giftName?: string;
+    giftUrl?: string;
+    listedPrice?: string;
+  };
   const isGiftRowSelected = (
     giftType: GiftType,
     giftIndex: number,
-    currentPrice?: string,
+    overrides?: GiftFieldOverrides,
   ) => {
     const gift =
       form.state.values.giftSelections[childIndex]?.[giftType][giftIndex];
     if (!gift) return false;
 
     return (
-      gift.giftName.trim() !== "" ||
-      gift.giftUrl.trim() !== "" ||
-      (currentPrice ?? gift.listedPrice).trim() !== ""
+      (overrides?.giftName ?? gift.giftName).trim() !== "" ||
+      (overrides?.giftUrl ?? gift.giftUrl).trim() !== "" ||
+      (overrides?.listedPrice ?? gift.listedPrice).trim() !== ""
     );
   };
 
@@ -133,10 +138,17 @@ export function GiftDetailsForm({
                   ? undefined
                   : {
                       onChange: ({ value }) => {
-                        if (i !== 0 && !value) return undefined;
-                        if (!value) return "URL is required";
+                        const trimmedValue = value.trim();
+                        const urlIsRequired =
+                          i === 0 ||
+                          isGiftRowSelected("gifts", i, {
+                            giftUrl: trimmedValue,
+                          });
+                        if (!trimmedValue) {
+                          return urlIsRequired ? "URL is required" : undefined;
+                        }
                         try {
-                          const url = new URL(value);
+                          const url = new URL(trimmedValue);
                           if (!["http:", "https:"].includes(url.protocol)) {
                             return "URL must start with http or https";
                           }
@@ -187,8 +199,17 @@ export function GiftDetailsForm({
                   ? undefined
                   : {
                       onChange: ({ value }) => {
-                        if (i !== 0 && !value) return undefined;
-                        if (!value) return GIFT_TITLE_REQUIRED_MESSAGE;
+                        const trimmedValue = value.trim();
+                        const nameIsRequired =
+                          i === 0 ||
+                          isGiftRowSelected("gifts", i, {
+                            giftName: trimmedValue,
+                          });
+                        if (!trimmedValue) {
+                          return nameIsRequired
+                            ? GIFT_TITLE_REQUIRED_MESSAGE
+                            : undefined;
+                        }
                         if (value.length > MAX_GIFT_TITLE_LENGTH) {
                           return getGiftTitleTooLongCounterMessage(
                             value.length,
@@ -226,7 +247,10 @@ export function GiftDetailsForm({
                   : {
                       onChange: ({ value }) => {
                         const priceIsRequired =
-                          i === 0 || isGiftRowSelected("gifts", i, value);
+                          i === 0 ||
+                          isGiftRowSelected("gifts", i, {
+                            listedPrice: value,
+                          });
                         if (!value.trim()) {
                           return priceIsRequired
                             ? "Price is required"

--- a/app/src/components/form/sections/GiftDetails.tsx
+++ b/app/src/components/form/sections/GiftDetails.tsx
@@ -1,13 +1,15 @@
-import { GiftIcon } from "@heroicons/react/24/solid";
+import { CurrencyDollarIcon, GiftIcon } from "@heroicons/react/24/solid";
 import type { useGiftsForm } from "@/hooks/family-form/formHooks";
 import { CardDescription } from "@/components/ui/card";
 import { useState, useRef } from "react";
 import { fetchProductDetails } from "@/server/functions/giftLinks";
 import {
   GIFT_FAMILY_PUBLIC_NOTES_TOO_LONG_MESSAGE,
+  GIFT_PRICE_INVALID_MESSAGE,
   GIFT_TITLE_REQUIRED_MESSAGE,
   GIFT_TITLE_TOO_LONG_MESSAGE,
   MAX_GIFT_FAMILY_PUBLIC_NOTES_LENGTH,
+  MAX_GIFT_PRICE,
   MAX_GIFT_TITLE_LENGTH,
   getGiftTitleTooLongCounterMessage,
 } from "common";
@@ -31,6 +33,20 @@ export function GiftDetailsForm({
   const lastFetchedUrlRef = useRef<Record<string, string>>({});
 
   type GiftType = "gifts" | "backupGifts";
+  const isGiftRowSelected = (
+    giftType: GiftType,
+    giftIndex: number,
+    currentPrice?: string,
+  ) => {
+    const gift = form.state.values.giftSelections[childIndex]?.[giftType][giftIndex];
+    if (!gift) return false;
+
+    return (
+      gift.giftName.trim() !== "" ||
+      gift.giftUrl.trim() !== "" ||
+      (currentPrice ?? gift.listedPrice).trim() !== ""
+    );
+  };
 
   const handleUrlBlur = async (
     key: string,
@@ -202,6 +218,45 @@ export function GiftDetailsForm({
             </form.AppField>
 
             <form.AppField
+              name={`giftSelections[${childIndex}].gifts[${i}].listedPrice`}
+              validators={
+                disabled
+                  ? undefined
+                  : {
+                      onChange: ({ value }) => {
+                        const priceIsRequired =
+                          i === 0 || isGiftRowSelected("gifts", i, value);
+                        if (!value.trim()) {
+                          return priceIsRequired
+                            ? "Price is required"
+                            : undefined;
+                        }
+                        const price = Number(value);
+                        if (
+                          !Number.isFinite(price) ||
+                          price < 0 ||
+                          price > MAX_GIFT_PRICE
+                        ) {
+                          return GIFT_PRICE_INVALID_MESSAGE;
+                        }
+                        return undefined;
+                      },
+                    }
+              }
+            >
+              {(field) => (
+                <field.FormFieldInput
+                  Icon={CurrencyDollarIcon}
+                  label={`Gift #${i + 1} Price${i !== 0 ? " (Optional unless selected)" : ""}`}
+                  placeholder="e.g. 19.99"
+                  inputMode="decimal"
+                  required={i === 0}
+                  disabled={disabled}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField
               name={`giftSelections[${childIndex}].gifts[${i}].familyPublicNotes`}
               validators={{
                 onChange: ({ value }) => {
@@ -329,6 +384,39 @@ export function GiftDetailsForm({
             </form.AppField>
 
             <form.AppField
+              name={`giftSelections[${childIndex}].backupGifts[${i}].listedPrice`}
+              validators={
+                disabled
+                  ? undefined
+                  : {
+                      onChange: ({ value }) => {
+                        if (!value.trim()) return "Price is required";
+                        const price = Number(value);
+                        if (
+                          !Number.isFinite(price) ||
+                          price < 0 ||
+                          price > MAX_GIFT_PRICE
+                        ) {
+                          return GIFT_PRICE_INVALID_MESSAGE;
+                        }
+                        return undefined;
+                      },
+                    }
+              }
+            >
+              {(field) => (
+                <field.FormFieldInput
+                  Icon={CurrencyDollarIcon}
+                  label={`Backup Gift #${i + 1} Price`}
+                  placeholder="e.g. 19.99"
+                  inputMode="decimal"
+                  required
+                  disabled={disabled}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField
               name={`giftSelections[${childIndex}].backupGifts[${i}].familyPublicNotes`}
               validators={{
                 onChange: ({ value }) => {
@@ -358,14 +446,6 @@ export function GiftDetailsForm({
         ))}
       </div>
 
-      <form.AppField name={`giftSelections[${childIndex}].verified`}>
-        {(field) => (
-          <field.FormCheckbox disabled={disabled}>
-            I verify that all selected gifts are $25 or under based on the
-            original price.
-          </field.FormCheckbox>
-        )}
-      </form.AppField>
     </div>
   );
 }

--- a/app/src/components/form/sections/GiftDetails.tsx
+++ b/app/src/components/form/sections/GiftDetails.tsx
@@ -38,7 +38,8 @@ export function GiftDetailsForm({
     giftIndex: number,
     currentPrice?: string,
   ) => {
-    const gift = form.state.values.giftSelections[childIndex]?.[giftType][giftIndex];
+    const gift =
+      form.state.values.giftSelections[childIndex]?.[giftType][giftIndex];
     if (!gift) return false;
 
     return (
@@ -445,7 +446,6 @@ export function GiftDetailsForm({
           </div>
         ))}
       </div>
-
     </div>
   );
 }

--- a/app/src/components/review/ChildCard.tsx
+++ b/app/src/components/review/ChildCard.tsx
@@ -481,7 +481,7 @@ export function ChildCard({ child }: ChildCardProps) {
                   onPriceChange={async (value) => {
                     const trimmedValue = value.trim();
                     if (trimmedValue === "") {
-                      collections.gifts.update(gift.id, (draft) => {
+                      editGift(gift.id, (draft) => {
                         draft.listedPrice = undefined;
                       });
                       return;

--- a/app/src/components/review/ChildCard.tsx
+++ b/app/src/components/review/ChildCard.tsx
@@ -100,6 +100,22 @@ export function ChildCard({ child }: ChildCardProps) {
     });
   };
 
+  const saveGiftPrice = async (
+    giftId: string,
+    listedPrice: number | undefined,
+  ) => {
+    try {
+      const tx = collections.gifts.update(giftId, (draft) => {
+        draft.listedPrice = listedPrice;
+      });
+      await tx.isPersisted.promise;
+      toast.success("Gift updated successfully");
+    } catch (error) {
+      toast.error("Save failed");
+      console.error("Gift price save failed", error);
+    }
+  };
+
   const invalidatePhotoRead = () => {
     photoReadIdRef.current += 1;
     photoReaderRef.current?.abort();
@@ -481,17 +497,25 @@ export function ChildCard({ child }: ChildCardProps) {
                   onPriceChange={async (value) => {
                     const trimmedValue = value.trim();
                     if (trimmedValue === "") {
-                      editGift(gift.id, (draft) => {
-                        draft.listedPrice = undefined;
-                      });
+                      if (editing) {
+                        editGift(gift.id, (draft) => {
+                          draft.listedPrice = undefined;
+                        });
+                      } else {
+                        await saveGiftPrice(gift.id, undefined);
+                      }
                       return;
                     }
 
                     const price = parsePriceInput(value);
                     if (hasValidListedPrice(price)) {
-                      collections.gifts.update(gift.id, (draft) => {
-                        draft.listedPrice = price;
-                      });
+                      if (editing) {
+                        editGift(gift.id, (draft) => {
+                          draft.listedPrice = price;
+                        });
+                      } else {
+                        await saveGiftPrice(gift.id, price);
+                      }
                     } else if (value.trim() !== "") {
                       toast.warning("Invalid price!");
                     }

--- a/app/src/components/review/ChildCard.tsx
+++ b/app/src/components/review/ChildCard.tsx
@@ -479,6 +479,14 @@ export function ChildCard({ child }: ChildCardProps) {
                     })
                   }
                   onPriceChange={async (value) => {
+                    const trimmedValue = value.trim();
+                    if (trimmedValue === "") {
+                      collections.gifts.update(gift.id, (draft) => {
+                        draft.listedPrice = undefined;
+                      });
+                      return;
+                    }
+
                     const price = parsePriceInput(value);
                     if (hasValidListedPrice(price)) {
                       collections.gifts.update(gift.id, (draft) => {

--- a/app/src/components/review/ReviewActionPanel.tsx
+++ b/app/src/components/review/ReviewActionPanel.tsx
@@ -23,7 +23,7 @@ import type { AuthUser } from "@/server/functions/auth";
 
 const CHECKLIST_ITEMS = [
   "No gift cards allowed",
-  "Gifts should be $25 or under",
+  "Gifts should be $30 or under",
   "Gift links must point to Amazon/Macy's only",
   "Profile pictures must be appropriate",
   "Personal blurbs must be appropriate",

--- a/app/src/hooks/family-form/formHooks.ts
+++ b/app/src/hooks/family-form/formHooks.ts
@@ -210,7 +210,7 @@ export function useGiftsForm() {
         })) as ChildGiftSelections["gifts"],
         backupGifts: [0, 1].map((giftIndex) => ({
           ...emptyGift,
-          ...existing.backupGifts[giftIndex],
+          ...(existing.backupGifts?.[giftIndex] ?? {}),
         })) as ChildGiftSelections["backupGifts"],
       };
     }

--- a/app/src/hooks/family-form/formHooks.ts
+++ b/app/src/hooks/family-form/formHooks.ts
@@ -192,27 +192,39 @@ export function useGiftsForm() {
   const { formState, updateSection } = useFormContext();
 
   const children = formState.children?.children || [];
+  const emptyGift = {
+    giftName: "",
+    giftUrl: "",
+    listedPrice: "",
+    familyPublicNotes: "",
+  };
 
   const reconciledGiftSelections = children.map((child, index) => {
     const existing = formState.gifts?.giftSelections[index];
     if (existing) {
       return {
-        ...existing,
         childName: child.name,
+        gifts: [0, 1, 2].map((giftIndex) => ({
+          ...emptyGift,
+          ...existing.gifts[giftIndex],
+        })) as ChildGiftSelections["gifts"],
+        backupGifts: [0, 1].map((giftIndex) => ({
+          ...emptyGift,
+          ...existing.backupGifts[giftIndex],
+        })) as ChildGiftSelections["backupGifts"],
       };
     }
     return {
       childName: child.name,
       gifts: [
-        { giftName: "", giftUrl: "" },
-        { giftName: "", giftUrl: "" },
-        { giftName: "", giftUrl: "" },
+        { giftName: "", giftUrl: "", listedPrice: "" },
+        { giftName: "", giftUrl: "", listedPrice: "" },
+        { giftName: "", giftUrl: "", listedPrice: "" },
       ],
       backupGifts: [
-        { giftName: "", giftUrl: "" },
-        { giftName: "", giftUrl: "" },
+        { giftName: "", giftUrl: "", listedPrice: "" },
+        { giftName: "", giftUrl: "", listedPrice: "" },
       ],
-      verified: false,
     } satisfies ChildGiftSelections;
   });
 

--- a/app/src/hooks/mutations/useSubmitFamilyForm.ts
+++ b/app/src/hooks/mutations/useSubmitFamilyForm.ts
@@ -41,6 +41,8 @@ export function buildFamilyFormSubmitPayload(
 function cleanChildrenObjects(
   children: NonNullable<FamilyFormState["children"]>,
 ): NonNullable<FamilyFormInput["children"]> {
+  const shouldIncludePhotos = children.consentPhotosPublic;
+
   return {
     ...children,
     additionalNotes: children.additionalNotes?.trim() ?? "",
@@ -50,6 +52,7 @@ function cleanChildrenObjects(
       hospitalTreatedAt: child.hospitalTreatedAt?.trim() ?? "",
       socialWorkerName: child.socialWorkerName?.trim() ?? "",
       treatmentLength: child.treatmentLength?.trim() ?? "",
+      photoUrl: shouldIncludePhotos ? child.photoUrl : "",
       blurb: child.blurb?.trim() ?? "",
     })),
   };
@@ -131,9 +134,13 @@ export function useSubmitFamilyForm() {
       const res = await submitFamilyForm({
         data: payload,
       });
+      const photosToUpload = payload.children?.consentPhotosPublic
+        ? photos
+        : [];
+
       //NOTE: Image data is base64 encoded data URLs. Images are at most 5mb. In order to avoid possible HTTP request body size limits, we need to split up uploads over multiple requests (one per image)
       const uploadResults = await Promise.allSettled(
-        photos.map(async (p, i) => {
+        photosToUpload.map(async (p, i) => {
           const id = res.childIds[i];
           const compressedImage = await compressImage(p);
 

--- a/app/src/hooks/mutations/useSubmitFamilyForm.ts
+++ b/app/src/hooks/mutations/useSubmitFamilyForm.ts
@@ -75,7 +75,34 @@ async function compressImage(dataUrl?: string): Promise<string | null> {
 function cleanGiftsObjects(
   g: GiftsFormData,
 ): NonNullable<FamilyFormInput["gifts"]> {
-  return g;
+  const normalizeGift = (
+    gift: GiftsFormData["giftSelections"][number]["gifts"][number],
+  ) => ({
+    ...gift,
+    giftName: gift.giftName.trim(),
+    giftUrl: gift.giftUrl.trim(),
+    listedPrice:
+      gift.listedPrice.trim() === ""
+        ? undefined
+        : Number(gift.listedPrice.trim()),
+    familyPublicNotes: gift.familyPublicNotes?.trim() ?? "",
+  });
+
+  return {
+    giftSelections: g.giftSelections.map((selection) => ({
+      ...selection,
+      childName: selection.childName.trim(),
+      gifts: [
+        normalizeGift(selection.gifts[0]),
+        normalizeGift(selection.gifts[1]),
+        normalizeGift(selection.gifts[2]),
+      ],
+      backupGifts: [
+        normalizeGift(selection.backupGifts[0]),
+        normalizeGift(selection.backupGifts[1]),
+      ],
+    })),
+  };
 }
 
 export function useSubmitFamilyForm() {

--- a/app/src/hooks/mutations/useSubmitFamilyForm.ts
+++ b/app/src/hooks/mutations/useSubmitFamilyForm.ts
@@ -6,6 +6,7 @@ import { submitFamilyForm } from "@/server/functions/familyForm";
 import Compressor from "compressorjs";
 import { uploadChildPictureAppCheck } from "@/server/functions/child";
 import { toast } from "@/lib/toast";
+import { GIFT_PRICE_INVALID_MESSAGE, MAX_GIFT_PRICE } from "common";
 
 export function buildFamilyFormSubmitPayload(
   formLinkId: string,
@@ -75,16 +76,29 @@ async function compressImage(dataUrl?: string): Promise<string | null> {
 function cleanGiftsObjects(
   g: GiftsFormData,
 ): NonNullable<FamilyFormInput["gifts"]> {
+  const normalizeListedPrice = (listedPrice: string) => {
+    const trimmedPrice = listedPrice.trim();
+    if (trimmedPrice === "") return undefined;
+
+    const numericPrice = Number(trimmedPrice);
+    if (
+      !Number.isFinite(numericPrice) ||
+      numericPrice < 0 ||
+      numericPrice > MAX_GIFT_PRICE
+    ) {
+      throw new Error(GIFT_PRICE_INVALID_MESSAGE);
+    }
+
+    return numericPrice;
+  };
+
   const normalizeGift = (
     gift: GiftsFormData["giftSelections"][number]["gifts"][number],
   ) => ({
     ...gift,
     giftName: gift.giftName.trim(),
     giftUrl: gift.giftUrl.trim(),
-    listedPrice:
-      gift.listedPrice.trim() === ""
-        ? undefined
-        : Number(gift.listedPrice.trim()),
+    listedPrice: normalizeListedPrice(gift.listedPrice),
     familyPublicNotes: gift.familyPublicNotes?.trim() ?? "",
   });
 

--- a/app/src/lib/firebase.ts
+++ b/app/src/lib/firebase.ts
@@ -30,7 +30,7 @@ declare global {
   var FIREBASE_APPCHECK_DEBUG_TOKEN: boolean | string | undefined;
 }
 
-if (import.meta.env.DEV) {
+if (import.meta.env.DEV && typeof self !== "undefined") {
   console.log("===USING APPCHECK DEBUG TOKEN===");
   self.FIREBASE_APPCHECK_DEBUG_TOKEN =
     import.meta.env.VITE_APPCHECK_DEBUG_TOKEN ?? true;

--- a/app/src/lib/formSchemas.ts
+++ b/app/src/lib/formSchemas.ts
@@ -270,7 +270,7 @@ function hasValidPrice(value: string) {
 
 const baseGiftSchema = z.object({
   giftName: GiftTitleSchema,
-  giftUrl: z.string(),
+  giftUrl: z.union([z.literal(""), z.url()]),
   listedPrice: z.string().trim(),
   familyPublicNotes: GiftFamilyPublicNotesSchema.optional(),
 });
@@ -279,7 +279,9 @@ const optionalGiftSchema = baseGiftSchema.superRefine((data, ctx) => {
   const hasName = data.giftName.trim().length > 0;
   const hasUrl = data.giftUrl.trim().length > 0;
   const hasPrice = data.listedPrice.length > 0;
-  const isBlank = !hasName && !hasUrl && !hasPrice;
+  const hasNotes = (data.familyPublicNotes?.trim() ?? "").length > 0;
+
+  const isBlank = !hasName && !hasUrl && !hasPrice && !hasNotes;
 
   if (isBlank) return;
 

--- a/app/src/lib/formSchemas.ts
+++ b/app/src/lib/formSchemas.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import {
   ChildStatusSchema,
   GiftFamilyPublicNotesSchema,
+  GIFT_PRICE_INVALID_MESSAGE,
+  GIFT_TITLE_REQUIRED_MESSAGE,
   GiftTitleSchema,
+  MAX_GIFT_PRICE,
 } from "common";
 import type { ChildStatus } from "common";
 
@@ -257,30 +260,106 @@ export const childrenFormSchema = z
     path: ["children"],
   });
 
-const giftSchema = z
-  .object({
-    giftName: GiftTitleSchema,
-    giftUrl: z.string(),
-    familyPublicNotes: GiftFamilyPublicNotesSchema.optional(),
-  })
-  .refine(
-    (data) => {
-      const hasName = data.giftName.trim().length > 0;
-      const hasUrl = data.giftUrl.trim().length > 0;
-      return (hasName && hasUrl) || (!hasName && !hasUrl);
-    },
-    {
-      message: "Both Name and URL are required if this gift is selected",
-    },
-  );
+const PRICE_REQUIRED_MESSAGE = "Price is required";
+const URL_REQUIRED_MESSAGE = "URL is required";
+
+function hasValidPrice(value: string) {
+  const price = Number(value);
+  return Number.isFinite(price) && price >= 0 && price <= MAX_GIFT_PRICE;
+}
+
+const baseGiftSchema = z.object({
+  giftName: GiftTitleSchema,
+  giftUrl: z.string(),
+  listedPrice: z.string().trim(),
+  familyPublicNotes: GiftFamilyPublicNotesSchema.optional(),
+});
+
+const optionalGiftSchema = baseGiftSchema.superRefine((data, ctx) => {
+  const hasName = data.giftName.trim().length > 0;
+  const hasUrl = data.giftUrl.trim().length > 0;
+  const hasPrice = data.listedPrice.length > 0;
+  const isBlank = !hasName && !hasUrl && !hasPrice;
+
+  if (isBlank) return;
+
+  if (!hasName) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["giftName"],
+      message: GIFT_TITLE_REQUIRED_MESSAGE,
+    });
+  }
+
+  if (!hasUrl) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["giftUrl"],
+      message: URL_REQUIRED_MESSAGE,
+    });
+  }
+
+  if (!hasPrice) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["listedPrice"],
+      message: PRICE_REQUIRED_MESSAGE,
+    });
+    return;
+  }
+
+  if (!hasValidPrice(data.listedPrice)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["listedPrice"],
+      message: GIFT_PRICE_INVALID_MESSAGE,
+    });
+  }
+});
+
+const requiredGiftSchema = baseGiftSchema.superRefine((data, ctx) => {
+  const hasName = data.giftName.trim().length > 0;
+  const hasUrl = data.giftUrl.trim().length > 0;
+  const hasPrice = data.listedPrice.length > 0;
+
+  if (!hasName) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["giftName"],
+      message: GIFT_TITLE_REQUIRED_MESSAGE,
+    });
+  }
+
+  if (!hasUrl) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["giftUrl"],
+      message: URL_REQUIRED_MESSAGE,
+    });
+  }
+
+  if (!hasPrice) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["listedPrice"],
+      message: PRICE_REQUIRED_MESSAGE,
+    });
+    return;
+  }
+
+  if (!hasValidPrice(data.listedPrice)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["listedPrice"],
+      message: GIFT_PRICE_INVALID_MESSAGE,
+    });
+  }
+});
 
 export const childGiftSchema = z.object({
   childName: z.string(),
-  gifts: z.tuple([giftSchema, giftSchema, giftSchema]),
-  backupGifts: z.tuple([giftSchema, giftSchema]),
-  verified: z.boolean().refine((val) => val === true, {
-    message: "You must agree the conditions",
-  }),
+  gifts: z.tuple([requiredGiftSchema, optionalGiftSchema, optionalGiftSchema]),
+  backupGifts: z.tuple([requiredGiftSchema, requiredGiftSchema]),
 });
 
 export const giftsFormSchema = z.object({

--- a/app/src/routes/family/form/$formLinkId/gift-details.tsx
+++ b/app/src/routes/family/form/$formLinkId/gift-details.tsx
@@ -58,7 +58,9 @@ function GiftsStep() {
     if (isComplete) return "completed";
 
     const hasGiftValue = (
-      gift: (typeof childData.gifts)[number] | (typeof childData.backupGifts)[number],
+      gift:
+        | (typeof childData.gifts)[number]
+        | (typeof childData.backupGifts)[number],
     ) =>
       gift.giftName.trim() !== "" ||
       gift.giftUrl.trim() !== "" ||

--- a/app/src/routes/family/form/$formLinkId/gift-details.tsx
+++ b/app/src/routes/family/form/$formLinkId/gift-details.tsx
@@ -57,9 +57,17 @@ function GiftsStep() {
 
     if (isComplete) return "completed";
 
+    const hasGiftValue = (
+      gift: (typeof childData.gifts)[number] | (typeof childData.backupGifts)[number],
+    ) =>
+      gift.giftName.trim() !== "" ||
+      gift.giftUrl.trim() !== "" ||
+      (gift.listedPrice?.trim() ?? "") !== "" ||
+      (gift.familyPublicNotes?.trim() ?? "") !== "";
+
     const isPristine =
-      childData.gifts.every((g) => g.giftName === "" && g.giftUrl === "") &&
-      childData.verified === false;
+      childData.gifts.every((gift) => !hasGiftValue(gift)) &&
+      childData.backupGifts.every((gift) => !hasGiftValue(gift));
 
     if (isPristine) return "pristine";
 
@@ -90,7 +98,7 @@ function GiftsStep() {
             </p>
             <ul className="flex flex-col gap-2 list-disc px-7">
               <li>
-                🎁 Gifts must be <strong>$25 or less</strong>, based on the{" "}
+                🎁 Gifts must be <strong>$30 or less</strong>, based on the{" "}
                 <strong>original price</strong> (not the sale price).
               </li>
               <li>

--- a/app/src/server/functions/familyForm.ts
+++ b/app/src/server/functions/familyForm.ts
@@ -62,7 +62,7 @@ const baseGiftSelectionSchema = z.object({
 const optionalGiftSelectionSchema = baseGiftSelectionSchema.superRefine(
   (data, ctx) => {
     const hasName = Boolean(data.giftName);
-    const hasUrl = data.giftUrl !== "";
+    const hasUrl = Boolean(data.giftUrl);
     const hasPrice = data.listedPrice !== undefined;
     const isBlank = !hasName && !hasUrl && !hasPrice;
 
@@ -149,9 +149,10 @@ const childGiftSelectionSchema = z.object({
     optionalGiftSelectionSchema,
     optionalGiftSelectionSchema,
   ]),
-  backupGifts: z
-    .tuple([requiredGiftSelectionSchema, requiredGiftSelectionSchema])
-    .optional(),
+  backupGifts: z.tuple([
+    requiredGiftSelectionSchema,
+    requiredGiftSelectionSchema,
+  ]),
 });
 
 const giftsFormSchema = z.object({
@@ -345,7 +346,7 @@ export const submitFamilyForm = createServerFn({ method: "POST" })
             };
           });
 
-        const backup = (selection.backupGifts ?? [])
+        const backup = selection.backupGifts
           .filter(hasGiftIdentity)
           .map((g): Gift => {
             const { giftName, giftUrl } = g;

--- a/app/src/server/functions/familyForm.ts
+++ b/app/src/server/functions/familyForm.ts
@@ -12,6 +12,9 @@ import {
   AddressSchema,
   ChildStatusSchema,
   GiftFamilyPublicNotesSchema,
+  GIFT_PRICE_INVALID_MESSAGE,
+  GIFT_TITLE_REQUIRED_MESSAGE,
+  MAX_GIFT_PRICE,
   NormalizedGiftTitleSchema,
 } from "common";
 
@@ -46,17 +49,109 @@ const childrenFormSchema = z.object({
   consentPhotosPublic: z.boolean(),
 });
 
-const giftSelectionSchema = z.object({
+const PRICE_REQUIRED_MESSAGE = "Price is required";
+const URL_REQUIRED_MESSAGE = "URL is required";
+
+const baseGiftSelectionSchema = z.object({
   giftUrl: z.url().optional().or(z.literal("")),
   giftName: NormalizedGiftTitleSchema.optional(),
+  listedPrice: z.number().min(0).max(MAX_GIFT_PRICE).optional(),
   familyPublicNotes: GiftFamilyPublicNotesSchema.optional(),
 });
 
+const optionalGiftSelectionSchema = baseGiftSelectionSchema.superRefine(
+  (data, ctx) => {
+    const hasName = Boolean(data.giftName);
+    const hasUrl = data.giftUrl !== "";
+    const hasPrice = data.listedPrice !== undefined;
+    const isBlank = !hasName && !hasUrl && !hasPrice;
+
+    if (isBlank) return;
+
+    if (!hasName) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["giftName"],
+        message: "Gift name is required.",
+      });
+    }
+
+    if (!hasUrl) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["giftUrl"],
+        message: URL_REQUIRED_MESSAGE,
+      });
+    }
+
+    if (!hasPrice) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["listedPrice"],
+        message: PRICE_REQUIRED_MESSAGE,
+      });
+      return;
+    }
+
+    const listedPrice = data.listedPrice;
+    if (listedPrice === undefined) return;
+    if (listedPrice < 0 || listedPrice > MAX_GIFT_PRICE) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["listedPrice"],
+        message: GIFT_PRICE_INVALID_MESSAGE,
+      });
+    }
+  },
+);
+
+const requiredGiftSelectionSchema = baseGiftSelectionSchema.superRefine(
+  (data, ctx) => {
+    if (!data.giftName) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["giftName"],
+        message: GIFT_TITLE_REQUIRED_MESSAGE,
+      });
+    }
+
+    if (!data.giftUrl) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["giftUrl"],
+        message: URL_REQUIRED_MESSAGE,
+      });
+    }
+
+    if (data.listedPrice === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["listedPrice"],
+        message: PRICE_REQUIRED_MESSAGE,
+      });
+      return;
+    }
+
+    if (data.listedPrice < 0 || data.listedPrice > MAX_GIFT_PRICE) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["listedPrice"],
+        message: GIFT_PRICE_INVALID_MESSAGE,
+      });
+    }
+  },
+);
+
 const childGiftSelectionSchema = z.object({
   childName: z.string(),
-  gifts: z.array(giftSelectionSchema),
-  backupGifts: z.array(giftSelectionSchema).optional(),
-  verified: z.boolean(),
+  gifts: z.tuple([
+    requiredGiftSelectionSchema,
+    optionalGiftSelectionSchema,
+    optionalGiftSelectionSchema,
+  ]),
+  backupGifts: z
+    .tuple([requiredGiftSelectionSchema, requiredGiftSelectionSchema])
+    .optional(),
 });
 
 const giftsFormSchema = z.object({
@@ -232,6 +327,7 @@ export const submitFamilyForm = createServerFn({ method: "POST" })
               giftDrive: giftDriveId,
               title: g.giftName,
               productUrl: g.giftUrl,
+              listedPrice: g.listedPrice,
               status: "AVAILABLE",
               backup: false,
               active: true,
@@ -241,8 +337,14 @@ export const submitFamilyForm = createServerFn({ method: "POST" })
           );
 
         const backup = (selection.backupGifts ?? [])
-          .filter((g): g is typeof g & { giftName: string; giftUrl: string } =>
-            Boolean(g.giftName && g.giftUrl),
+          .filter(
+            (
+              g,
+            ): g is typeof g & {
+              giftName: string;
+              giftUrl: string;
+              listedPrice?: number;
+            } => Boolean(g.giftName && g.giftUrl),
           )
           .map(
             (g): Gift => ({
@@ -250,8 +352,9 @@ export const submitFamilyForm = createServerFn({ method: "POST" })
               childId,
               familyId,
               giftDrive: giftDriveId,
-              title: g.giftName,
-              productUrl: g.giftUrl,
+              title: g.giftName!,
+              productUrl: g.giftUrl!,
+              listedPrice: g.listedPrice,
               status: "AVAILABLE",
               backup: true,
               active: true,

--- a/app/src/server/functions/familyForm.ts
+++ b/app/src/server/functions/familyForm.ts
@@ -171,6 +171,12 @@ const familyEmailSchema = z.object({
 
 export type FamilyFormInput = z.infer<typeof familyFormStateSchema>;
 
+function hasGiftIdentity<T extends { giftName?: string; giftUrl?: string }>(
+  gift: T,
+): gift is T & { giftName: string; giftUrl: string } {
+  return Boolean(gift.giftName && gift.giftUrl);
+}
+
 function normalizeFamilyEmail(email: string) {
   return email.trim().toLowerCase();
 }
@@ -316,52 +322,52 @@ export const submitFamilyForm = createServerFn({ method: "POST" })
         const childId = childIds[idx];
 
         const regular = selection.gifts
-          .filter((g): g is typeof g & { giftName: string; giftUrl: string } =>
-            Boolean(g.giftName && g.giftUrl),
-          )
-          .map(
-            (g): Gift => ({
+          .filter(hasGiftIdentity)
+          .map((g): Gift => {
+            const { giftName, giftUrl } = g;
+            if (!giftName || !giftUrl) {
+              throw new Error("Gift selections must include both name and URL");
+            }
+
+            return {
               id: uuidv7(),
               childId,
               familyId,
               giftDrive: giftDriveId,
-              title: g.giftName,
-              productUrl: g.giftUrl,
+              title: giftName,
+              productUrl: giftUrl,
               listedPrice: g.listedPrice,
               status: "AVAILABLE",
               backup: false,
               active: true,
               createdAt: now,
               familyPublicNotes: g.familyPublicNotes,
-            }),
-          );
+            };
+          });
 
         const backup = (selection.backupGifts ?? [])
-          .filter(
-            (
-              g,
-            ): g is typeof g & {
-              giftName: string;
-              giftUrl: string;
-              listedPrice?: number;
-            } => Boolean(g.giftName && g.giftUrl),
-          )
-          .map(
-            (g): Gift => ({
+          .filter(hasGiftIdentity)
+          .map((g): Gift => {
+            const { giftName, giftUrl } = g;
+            if (!giftName || !giftUrl) {
+              throw new Error("Gift selections must include both name and URL");
+            }
+
+            return {
               id: uuidv7(),
               childId,
               familyId,
               giftDrive: giftDriveId,
-              title: g.giftName!,
-              productUrl: g.giftUrl!,
+              title: giftName,
+              productUrl: giftUrl,
               listedPrice: g.listedPrice,
               status: "AVAILABLE",
               backup: true,
               active: true,
               createdAt: now,
               familyPublicNotes: g.familyPublicNotes,
-            }),
-          );
+            };
+          });
 
         return [...regular, ...backup];
       },

--- a/common/src/validation.ts
+++ b/common/src/validation.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 export const MAX_CHILD_PUBLIC_BLURB_LENGTH = 150;
 export const MAX_GIFT_FAMILY_PUBLIC_NOTES_LENGTH = 150;
 export const MAX_GIFT_TITLE_LENGTH = 50;
+export const MAX_GIFT_PRICE = 30;
 
 export const CHILD_PUBLIC_BLURB_TOO_LONG_MESSAGE = `Personal blurb must be ${MAX_CHILD_PUBLIC_BLURB_LENGTH} characters or fewer.`;
 export const GIFT_FAMILY_PUBLIC_NOTES_TOO_LONG_MESSAGE = `Gift notes must be ${MAX_GIFT_FAMILY_PUBLIC_NOTES_LENGTH} characters or fewer.`;
 export const GIFT_TITLE_TOO_LONG_MESSAGE = `Gift name must be ${MAX_GIFT_TITLE_LENGTH} characters or fewer.`;
 export const GIFT_TITLE_REQUIRED_MESSAGE = "Gift name is required.";
+export const GIFT_PRICE_INVALID_MESSAGE = `Price must be a valid non-negative number no greater than $${MAX_GIFT_PRICE}.`;
 
 export const ChildPublicBlurbSchema = z
   .string()


### PR DESCRIPTION
# Pull Request
adds price input into family form. field only required for required gifts + non-empy gifts. updated to max $30 gifts

sm add: Changed the family form submit path so uploaded images are ignored unless consentPhotosPublic is checked in family form
## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues (put task name here from notion)

<!-- Link any related issues here (e.g., Closes #123) -->

## Screenshots (If it is a front end feature screenshot is required)

<!-- If applicable, add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gift listed-price fields and validation for child gifts and backup gifts, with allowed prices up to **$30**.
  * Updated gift guidance to reflect the new **$30** limit.

* **Bug Fixes**
  * Clearing a gift price now removes the previously saved value instead of keeping it.
  * “Pristine” step status now updates based on entered gift details (including optional listed prices) and notes.

* **Chores**
  * Removed the gift verification checkbox from the form flow.
  * Gift submission and payload handling now normalize and validate listed-price data consistently (and align photo uploads with consent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->