### PR TITLE
Waiting for review #128

### DIFF
--- a/app/src/components/form/FormComponents.tsx
+++ b/app/src/components/form/FormComponents.tsx
@@ -96,7 +96,7 @@ export function FormCheckbox({
         checked={field.state.value ?? value}
         onCheckedChange={(checked) => field.handleChange(!!checked)}
         disabled={disabled}
-        className="mt-0.5"
+        className="mt-0.5 border-2 border-slate-400"
       />
       <label htmlFor={checkboxId} className="text-sm cursor-pointer">
         {children}
@@ -402,7 +402,7 @@ export function FormTextarea({
         onChange={(e) => field.handleChange(e.target.value)}
         onBlur={field.handleBlur}
         disabled={disabled}
-        className={`resize-none min-h-[100px] ${errorMessage ? "border-red-500" : ""}`}
+        className={`resize-none min-h-[100px] ${errorMessage ? "border-red-500" : "border-slate-700"}`}
       />
       {maxLength !== undefined && !disabled && (
         <p
@@ -415,7 +415,7 @@ export function FormTextarea({
       )}
       {maxWords !== undefined && maxLength === undefined && !disabled && (
         <p className="text-xs text-right text-slate-500">
-          {wordCount} out of {maxWords}
+          {wordCount}/{maxWords} words
         </p>
       )}
       {errorMessage && (
@@ -457,7 +457,7 @@ export function FormAgreement({
           checked={field.state.value}
           onCheckedChange={(checked) => field.handleChange(!!checked)}
           disabled={disabled}
-          className="mt-0.5"
+          className="mt-0.5 border-2 border-slate-400"
         />
         <label htmlFor={checkboxId} className="text-sm cursor-pointer">
           {checkboxLabel}

--- a/app/src/components/form/sections/GeneralInfo.tsx
+++ b/app/src/components/form/sections/GeneralInfo.tsx
@@ -48,7 +48,7 @@ export function GeneralInfoForm({
   disabled = false,
 }: GeneralInfoFormProps) {
   return (
-    <>
+    <div className="flex flex-col gap-10">
       <div>
         <div className="border-b-2 border-kfk-blue w-full mb-8">
           <h2 className="text-xl font-bold text-kfk-blue pb-1">
@@ -307,6 +307,6 @@ export function GeneralInfoForm({
           )}
         </form.AppField>
       </div>
-    </>
+    </div>
   );
 }

--- a/app/src/routes/family/form/$formLinkId/gift-details.tsx
+++ b/app/src/routes/family/form/$formLinkId/gift-details.tsx
@@ -41,8 +41,15 @@ function GiftsStep() {
   const { formLinkId } = Route.useParams();
   const { childIndex } = Route.useSearch();
 
+  const safeChildIndex =
+    childIndex != null &&
+    childIndex >= 0 &&
+    childIndex < childrenNameList.length
+      ? childIndex
+      : null;
+
   const [activeChildIndex, setActiveChildIndex] = useState<number | null>(
-    childIndex ?? null,
+    safeChildIndex,
   );
 
   const form = useGiftsForm();

--- a/app/src/routes/family/form/$formLinkId/gift-details.tsx
+++ b/app/src/routes/family/form/$formLinkId/gift-details.tsx
@@ -7,6 +7,7 @@ import {
   XCircleIcon,
 } from "@heroicons/react/24/solid";
 import { useState } from "react";
+import { z } from "zod";
 import { useFormContext } from "@/components/providers/FormProvider";
 import { childGiftSchema, giftsFormSchema } from "@/lib/formSchemas";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,9 @@ import { GiftDetailsForm } from "@/components/form/sections/GiftDetails";
 import LadyBug from "@/assets/form/ladybug.png";
 
 export const Route = createFileRoute("/family/form/$formLinkId/gift-details")({
+  validateSearch: z.object({
+    childIndex: z.number().optional(),
+  }),
   head: () => ({
     meta: [
       { title: "Gift Details - Family Registration" },
@@ -35,8 +39,11 @@ function GiftsStep() {
     (c) => c.name,
   );
   const { formLinkId } = Route.useParams();
+  const { childIndex } = Route.useSearch();
 
-  const [activeChildIndex, setActiveChildIndex] = useState<number | null>(null);
+  const [activeChildIndex, setActiveChildIndex] = useState<number | null>(
+    childIndex ?? null,
+  );
 
   const form = useGiftsForm();
 
@@ -204,20 +211,37 @@ function GiftsStep() {
           childName={childrenNameList[activeChildIndex]}
         />
 
-        <Button
-          type="button"
-          onClick={() => {
-            if (document.activeElement instanceof HTMLElement) {
-              document.activeElement.blur();
-            }
-            setActiveChildIndex(null);
-          }}
-          variant="outline"
-          className="flex h-14 rounded-xl border-2 border-kfk-blue text-kfk-blue font-bold text-lg"
-        >
-          <ChevronLeftIcon className="mr-2 h-6 w-6" />
-          Back
-        </Button>
+        <FormItem className="flex gap-4">
+          <Button
+            type="button"
+            onClick={() => {
+              if (document.activeElement instanceof HTMLElement) {
+                document.activeElement.blur();
+              }
+              setActiveChildIndex(null);
+            }}
+            variant="outline"
+            className="flex-1 h-14 rounded-xl border-2 border-kfk-blue text-kfk-blue font-bold text-lg"
+          >
+            <ChevronLeftIcon className="mr-2 h-6 w-6" />
+            Back
+          </Button>
+          {activeChildIndex < childrenNameList.length - 1 && (
+            <Button
+              type="button"
+              onClick={() => {
+                if (document.activeElement instanceof HTMLElement) {
+                  document.activeElement.blur();
+                }
+                setActiveChildIndex(activeChildIndex + 1);
+              }}
+              className="flex-1 h-14 rounded-xl bg-kfk-blue text-white font-bold text-lg"
+            >
+              Next
+              <ChevronRightIcon className="ml-2 h-6 w-6" />
+            </Button>
+          )}
+        </FormItem>
       </div>
     </div>
   );

--- a/app/src/routes/family/form/$formLinkId/review.tsx
+++ b/app/src/routes/family/form/$formLinkId/review.tsx
@@ -37,7 +37,7 @@ type SectionHeaderProps = {
 function SectionHeader({ title, onEdit }: SectionHeaderProps) {
   return (
     <div className="flex justify-between border-b-2 border-[var(--color-kfk-blue)] w-full mb-8">
-      <h2 className="text-xl font-bold text-[var(--color-kfk-blue)] pb-1">
+      <h2 className="text-2xl font-bold text-[var(--color-kfk-blue)] pb-1">
         {title}
       </h2>
       <button
@@ -103,6 +103,7 @@ function RouteComponent() {
               navigate({
                 to: "/family/form/$formLinkId/gift-details",
                 params: { formLinkId },
+                search: { childIndex: index },
               })
             }
           />


### PR DESCRIPTION
# Pull Request

## Description

- Matched the word count caption so it reads "0/100 words" instead of "0 out of 100"
- increased checkboxes border size and made border color grey to match figma
- added a "next child" button that will cycle to the next child if one exists, the next button will not appear for the last child in the list.
- fixed in review page, added space between address title bar and re-enter phone number field
- in review page the "General Information" and "Child Information" sections made bigger 
- in review and gift selection sections, the border style of the public notes section now matches the borders of the other text boxes
- in review page, clicking on "edit" for a child will jump to their section

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved child-specific navigation by passing a `childIndex` through the gift details flow and using it to initialize the correct active child.
  * Added runtime validation for the optional `childIndex` parameter and refined Back/Next behavior for single-child navigation.

* **UI Improvements**
  * Refined checkbox and textarea styling and improved non-error textarea border presentation.
  * Updated textarea word counter to show `current/max words`.
  * Adjusted form section layout spacing and increased the review section header size for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->